### PR TITLE
Dockerfile enhancements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.env
+node_modules
+.DS_Store
+coverage
+yarn-error.log
+.eslintcache
+dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,31 @@
-FROM node:alpine
+# Latest Debian-based Node LTS
+ARG NODE_VERSON=20.15-bookworm-slim
 
-RUN apk --no-cache --update add \
-  build-base \
-  python3
+FROM node:${NODE_VERSON}
+
+# Install git (used by yarn install)
+RUN apt-get update -y
+RUN apt-get install -y git
 
 WORKDIR /usr/app
 
+# Install packages first
+# Provided that package.json does not change,
+#  this will cache and have zero cost
 COPY ./package.json ./
+RUN yarn install --frozen-lockfile
+
+# Add non-root user to system
+RUN useradd -ms /bin/bash scl-user
+
 COPY ./tsconfig.json ./
-COPY ./environment.d.ts ./
+# TODO:  Do not embed environment files directly
+#COPY ./environment.d.ts ./
 COPY ./src ./
 
-RUN yarn install
 RUN yarn tsc
+
+# Switch to non-privileged user
+USER scl-user
 
 CMD [ "yarn", "prod:serve" ]


### PR DESCRIPTION
- Use pinned version of node
- Switch from alpine to Debian bookworm
- Add .dockerignore
- Move package install to separate layer
- Use non-privileged user to run server (default port 1337 is fine)
- Remove possibly unused python3

Build is currently broken within a docker context